### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Start a multi-agent simulation:
 python3 main.py --num-agents 2 --level partial-divider_salad --gpt
 ```
 
-Mannually control agents with arrow keys (switch between agents by pressing 1 or 2):
+Manually control agents with arrow keys (switch between agents by pressing 1 or 2):
 ```
 python3 main.py --num-agents 2 --level partial-divider_salad --gpt --manual
 ```


### PR DESCRIPTION
## Summary
- fix a spelling error in README describing manual agent control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bdbea6248332851eb7f5cf7efe46